### PR TITLE
Implement haxe.CallStack for Python

### DIFF
--- a/std/haxe/CallStack.hx
+++ b/std/haxe/CallStack.hx
@@ -101,6 +101,14 @@ class CallStack {
 			return stack;
 		#elseif cs
 			return makeStack(new cs.system.diagnostics.StackTrace(1, true));
+		#elseif python
+			var stack = [];
+			var infos = python.lib.Traceback.extract_stack();
+			infos.pop();
+			infos.reverse();
+			for (elem in infos)
+				stack.push(FilePos(null, elem._1, elem._2));
+			return stack;
 		#else
 			return []; // Unsupported
 		#end
@@ -159,6 +167,17 @@ class CallStack {
 			return stack;
 		#elseif cs
 			return makeStack(new cs.system.diagnostics.StackTrace(cs.internal.Exceptions.exception, true));
+		#elseif python
+			var stack = [];
+			var exc = python.lib.Sys.exc_info();
+			if (exc._3 != null)
+			{
+				var infos = python.lib.Traceback.extract_tb(exc._3);
+				infos.reverse();
+				for (elem in infos)
+					stack.push(FilePos(null, elem._1, elem._2));
+			}
+			return stack;
 		#else
 			return []; // Unsupported
 		#end

--- a/std/python/lib/Sys.hx
+++ b/std/python/lib/Sys.hx
@@ -24,6 +24,8 @@ extern class Sys {
 
 	public static var maxsize:Int;
 
+	public static function exc_info<T:BaseException>():Tup3<Class<T>, T, TB>;
+
 	static function __init__ ():Void
 	{
 		python.Syntax.importAs("sys", "python.lib.Sys");

--- a/std/python/lib/Traceback.hx
+++ b/std/python/lib/Traceback.hx
@@ -1,0 +1,15 @@
+package python.lib;
+
+import python.lib.Types;
+
+extern class Traceback {
+
+	public static function extract_stack(?f:Frame, ?limit:Int):Array<StackItem>;
+	public static function extract_tb(tb:TB, ?limit:Int):Array<StackItem>;
+
+	static function __init__ ():Void {
+		python.Syntax.importAs("traceback", "python.lib.Traceback");
+	}
+}
+
+private typedef StackItem = Tup4<String, Int, String, String>;

--- a/std/python/lib/Types.hx
+++ b/std/python/lib/Types.hx
@@ -707,3 +707,6 @@ extern class ResourceWarning extends Warning
 {
 
 }
+
+extern class TB {}
+extern class Frame {}


### PR DESCRIPTION
Added very basic implementation. Here's some code to play with:

``` haxe
import haxe.CallStack;

class Main
{
    static function main()
    {
        f();
    }

    static function f()
    {
        var m = new Main();
        function z() m.a();
        z();
    }

    function new() {}

    function a()
    {
        trace(CallStack.toString(CallStack.callStack()));

        try
        {
            lol();
        }
        catch (e:Dynamic)
        {
            haha();
        }
    }

    function lol() throw "fu";
    function haha() trace(CallStack.toString(CallStack.exceptionStack()));
}
```
