### PR TITLE
Unify call args rewrite

### DIFF
--- a/typer.ml
+++ b/typer.ml
@@ -728,7 +728,7 @@ let unify_field_call ctx fa el args ret p inline =
 			let cfl = if cf.cf_name = "new" || not (Meta.has Meta.Overload cf.cf_meta && ctx.com.config.pf_overload) then
 				List.map map_cf cf.cf_overloads
 			else
-				Typeload.get_overloads c cf.cf_name
+				List.map (fun (t,cf) -> (monomorphs cf.cf_params t), cf) (Typeload.get_overloads c cf.cf_name)
 			in
 			let map t =
 (* 				let error_printer file line = Printf.sprintf "%s:%d:" file line in
@@ -758,7 +758,6 @@ let unify_field_call ctx fa el args ret p inline =
 			candidates,err :: failures
 		end
 	) ([],[]) candidates in
-	(* List.iter (fun (el,tf,_) -> ctx.com.warning (s_type (print_context()) tf) p) candidates; *)
 	let candidates = if is_overload && ctx.com.config.pf_overload then
 		Codegen.Overloads.reduce_compatible candidates
 	else


### PR DESCRIPTION
It's still not perfect. There are two problems:
On the Java target, the unit tests cannot compile with the following error:

```
/usr/lib/haxe/std/java/_std/haxe/ds/WeakMap.hx:409: characters 11-18 : java.lang.ref.WeakReference.T should be haxe.ds.WeakMap.K
```

It seems that this comes from `WeakReference::get()` being seen as returning `T`, not `K`. This seems to come from an inversion of parameters somewhere. See the private class Entry.

On the C# target, it fails at runtime because it can't find `_IndexOf`. `_IndexOf` is a static function which later had its name changed to `IndexOf` with the `@:native` metadata. It seems that the classfield at `FStatic` is a copy, since the cf_name change didn't propagate to that instance.

We'll talk better about those tomorrow! See ya
