### PR TITLE
[cs] SomeType >> _ is always of type SomeType

### DIFF
--- a/gencommon.ml
+++ b/gencommon.ml
@@ -6258,6 +6258,8 @@ struct
 				| TBinop ( (Ast.OpAssign | Ast.OpAssignOp _ as op), e1, e2 ) ->
 					let e1 = run ~just_type:true e1 in
 					{ e with eexpr = TBinop(op, clean_cast e1, run e2) }
+				| TBinop( (Ast.OpShl | Ast.OpShr | Ast.OpUShr) as op, e1, e2 ) ->
+					handle { e with eexpr = TBinop(op, run e1, run e2); etype = e1.etype } (gen.greal_type e.etype) (gen.greal_type e1.etype)
 				| TField(ef, f) ->
 					handle_type_parameter gen None e (run ef) ~clean_ef:ef ~overloads_cast_to_base:overloads_cast_to_base f [] calls_parameters_explicitly
 				| TArrayDecl el ->


### PR DESCRIPTION
I haven't done too much here.
All the errors for the C# compiler are either about UInt or about some C#-specific behaviour. In special, `cs.Out` and `cs.Ref`. They are special typedefs that should only be used in function arguments that expect an actual variable - not a constant.
They work like the `addressOf` (`&`) operator in C. If we cancel optimizations on those cases, I think we'll be able to compile C# fine as well.
