### PR TITLE
[spod] Add TType sys.db.SNull case check

### DIFF
--- a/std/sys/db/RecordMacros.hx
+++ b/std/sys/db/RecordMacros.hx
@@ -163,6 +163,9 @@ class RecordMacros {
 					return c;
 				csup = csup.t.get().superClass;
 			}
+		case TType(t,[p]) if(t.toString() == "sys.db.SNull"):
+			isNull = true;
+			return makeRecord(p);
 		case TAbstract(t, p):
 			var name = t.toString();
 			if( p.length == 1 && (name == "Null" || name == "sys.db.SNull") ) {


### PR DESCRIPTION
Okay
So this gets it to compile on the Haxe side on Java/C#. But some strange things happen

For example, Issue3031's `-D dump` looks like this:

```
    testArty(method) : Void -> Void

     = [Function:Void -> Void]
        [Block:Void]
            [Var a(31461):String] [Const "":String]
            [Block:Unknown<692>]
                [Var _g(31462):StringBuf] [New:StringBuf] StringBuf
                [Block:Unknown<692>]
                    [Var notNull(31464):StringBuf] [Local _g(31462):StringBuf]
                    [If:String]
                        [Parenthesis:Bool]
                            [Binop:Bool]
                                [Local _g(31462):StringBuf]
                                ==
                                [Const null:Null<Int>]
                        [Then:String] [Binop:String]
                            [Local a(31461):String]
                            =
                            [Const "null":String]
                        [Else:Unknown<691>] [Switch:Unknown<691>]
                            [Parenthesis:StringBuf] [Local _g(31462):StringBuf]
                            [Default:String]
                                [Binop:String]
                                    [Local a(31461):String]
                                    =
                                    [Const "not null":String]
            [Call:Void]
                [Field:v : String -> v2 : String -> ?pos : Null<haxe.PosInfos> -> Void]
                    [Const this:unit.issues.Issue3031]
                    [FInstance:v : String -> v2 : String -> ?pos : Null<haxe.PosInfos> -> Void]
                        unit.Test
                        eq
                [Const "not null":String]
                [Local a(31461):String]
                [ObjectDecl:{ methodName : String, lineNumber : Int, fileName : String, className : String }]
                    fileName: [Const "Issue3031.hx":String]
                    lineNumber: [Const 17:Int]
                    className: [Const "unit.issues.Issue3031":String]
                    methodName: [Const "testArty":String]
```

Look specially at this:

```
                    [If:String]
                        [Parenthesis:Bool]
                            [Binop:Bool]
                                [Local _g(31462):StringBuf]
                                ==
                                [Const null:Null<Int>]
```

It's comparing a `StringBuf` to a `Null<Int>`
