### PR TITLE
Bring back VArray and VString

### DIFF
--- a/src/macro/eval/evalContext.ml
+++ b/src/macro/eval/evalContext.ml
@@ -163,20 +163,10 @@ let rec kind_name ctx kind =
 	loop kind ctx.environment_offset
 
 let vstring s =
-	let proto = (get_ctx()).string_prototype in
-	vinstance {
-		ifields = [|vint (Rope.length s)|];
-		iproto = proto;
-		ikind = IString(s,lazy (Rope.to_string s))
-	}
+	VString (s,lazy (Rope.to_string s))
 
 let vstring_direct (r,s) =
-	let proto = (get_ctx()).string_prototype in
-	vinstance {
-		ifields = [|vint (Rope.length r)|];
-		iproto = proto;
-		ikind = IString(r,s)
-	}
+	VString(r,s)
 
 let call_function f vl = match f,vl with
 	| Fun0 f,_ -> f()

--- a/src/macro/eval/evalDebug.ml
+++ b/src/macro/eval/evalDebug.ml
@@ -111,7 +111,7 @@ let value_string value =
 		| VFloat f -> "Float",string_of_float f
 		| VEnumValue ev -> rev_hash_s ev.epath,Rope.to_string (s_enum_value 0 ev)
 		| VObject o -> "Anonymous",fields_string (depth + 1) (object_fields o)
-		| VInstance {ikind = IString(_,s)} -> "String","\"" ^ (Ast.s_escape (Lazy.force s)) ^ "\""
+		| VString(_,s) -> "String","\"" ^ (Ast.s_escape (Lazy.force s)) ^ "\""
 		| VInstance {ikind = IArray va} -> "Array",Rope.to_string (s_array (depth + 1) va)
 		| VInstance vi -> rev_hash_s vi.iproto.ppath,instance_fields (depth + 1) vi
 		| VPrototype proto -> "Anonymous",Rope.to_string (s_proto_kind proto)
@@ -369,7 +369,7 @@ module DebugOutputJson = struct
 					| vl -> name ^ "(...)"
 				end
 			| VObject o -> "{...}"
-			| VInstance {ikind = IString(_,s)} -> string_repr s
+			| VString(_,s) -> string_repr s
 			| VInstance {ikind = IArray va} -> "[...]"
 			| VInstance vi -> (rev_hash_s vi.iproto.ppath) ^ " {...}"
 			| VPrototype proto -> Rope.to_string (s_proto_kind proto)
@@ -402,7 +402,7 @@ module DebugOutputJson = struct
 				in
 				jv type_s value_s is_structured
 			| VObject o -> jv "Anonymous" (fields_string (object_fields o)) true (* TODO: false for empty structures *)
-			| VInstance {ikind = IString(_,s)} -> jv "String" (string_repr s) false
+			| VString(_,s) -> jv "String" (string_repr s) false
 			| VInstance {ikind = IArray va} -> jv "Array" (array_elems va) true (* TODO: false for empty arrays *)
 			| VInstance vi ->
 				let class_name = rev_hash_s vi.iproto.ppath in
@@ -557,7 +557,7 @@ module DebugOutputJson = struct
 					let a = access ^ "." ^ n in
 					n, v, a
 				) fields
-			| VInstance {ikind = IString(_,s)} -> []
+			| VString(_,s) -> []
 			| VInstance {ikind = IArray va} ->
 				let l = EvalArray.to_list va in
 				List.mapi (fun i v ->

--- a/src/macro/eval/evalDecode.ml
+++ b/src/macro/eval/evalDecode.ml
@@ -46,15 +46,15 @@ let decode_varray v = match v with
 	| _ -> unexpected_value v "array"
 
 let decode_string v = match v with
-	| VInstance {ikind = IString(r,s)} -> Lazy.force s
+	| VString(r,s) -> Lazy.force s
 	| _ -> unexpected_value v "string"
 
 let decode_rope v = match v with
-	| VInstance {ikind = IString(s,_)} -> s
+	| VString(s,_) -> s
 	| _ -> unexpected_value v "string"
 
 let decode_rope_string v = match v with
-	| VInstance {ikind = IString(r,s)} -> r,s
+	| VString(r,s) -> r,s
 	| _ -> unexpected_value v "string"
 
 let decode_bytes v = match v with

--- a/src/macro/eval/evalDecode.ml
+++ b/src/macro/eval/evalDecode.ml
@@ -38,11 +38,11 @@ let decode_instance v = match v with
 	| _ -> unexpected_value v "instance"
 
 let decode_array v = match v with
-	| VInstance {ikind = IArray va} -> EvalArray.to_list va
+	| VArray va -> EvalArray.to_list va
 	| _ -> unexpected_value v "array"
 
 let decode_varray v = match v with
-	| VInstance {ikind = IArray va} -> va
+	| VArray va -> va
 	| _ -> unexpected_value v "array"
 
 let decode_string v = match v with

--- a/src/macro/eval/evalEmitter.ml
+++ b/src/macro/eval/evalEmitter.ml
@@ -492,6 +492,7 @@ let emit_proto_field_call proto i execs p =
 let emit_method_call exec name execs p =
 	let vf vthis = match vthis with
 		| VInstance {iproto = proto} | VPrototype proto -> proto_field_raise proto name
+		| VString _ -> proto_field_raise (get_ctx()).string_prototype name
 		| _ -> unexpected_value_p vthis "instance" p
 	in
 	match execs with
@@ -781,10 +782,12 @@ let emit_proto_field_read proto i env =
 
 let emit_instance_local_field_read iv i env = match env.env_locals.(iv) with
 	| VInstance vi -> vi.ifields.(i)
+	| VString(_,s) -> vint (String.length (Lazy.force s))
 	| v -> unexpected_value v "instance"
 
 let emit_instance_field_read exec i env = match exec env with
 	| VInstance vi -> vi.ifields.(i)
+	| VString(_,s) -> vint (String.length (Lazy.force s))
 	| v -> unexpected_value v "instance"
 
 let emit_field_closure exec name env =
@@ -1045,9 +1048,9 @@ let op_add v1 v2 = match v1,v2 with
 	| VInt32 i1,VInt32 i2 -> vint32 (Int32.add i1 i2)
 	| VFloat f1,VFloat f2 -> vfloat (f1 +. f2)
 	| VInt32 i,VFloat f | VFloat f,VInt32 i -> vfloat ((Int32.to_float i) +. f)
-	| VInstance {ikind = IString(s1,_)},VInstance {ikind = IString(s2,_)} -> encode_rope (Rope.concat2 s1 s2)
-	| VInstance {ikind = IString(s1,_)},v2 -> encode_rope (Rope.concat2 s1 (s_value 0 v2))
-	| v1,VInstance {ikind = IString(s2,_)} -> encode_rope (Rope.concat2 (s_value 0 v1) s2)
+	| VString(s1,_),VString(s2,_) -> encode_rope (Rope.concat2 s1 s2)
+	| VString(s1,_),v2 -> encode_rope (Rope.concat2 s1 (s_value 0 v2))
+	| v1,VString(s2,_) -> encode_rope (Rope.concat2 (s_value 0 v1) s2)
 	| v1,v2 -> encode_rope (Rope.concat2 (s_value 0 v1) (s_value 0 v2))
 
 let op_mult p v1 v2 = match v1,v2 with

--- a/src/macro/eval/evalEmitter.ml
+++ b/src/macro/eval/evalEmitter.ml
@@ -770,7 +770,7 @@ let emit_local_read i env = env.env_locals.(i)
 let emit_capture_read i env = !(env.env_captures.(i))
 
 let emit_array_length_read exec env = match exec env with
-	| VInstance {ikind = IArray va} -> vint (va.alength)
+	| VArray va -> vint (va.alength)
 	| v -> unexpected_value v "Array"
 
 let emit_bytes_length_read exec env = match exec env with

--- a/src/macro/eval/evalEncode.ml
+++ b/src/macro/eval/evalEncode.ml
@@ -115,12 +115,7 @@ let encode_array l =
 	encode_array_instance (EvalArray.create (Array.of_list l))
 
 let encode_string s =
-	let proto = (get_ctx()).string_prototype in
-	vinstance {
-		ifields = [|vint (String.length s)|];
-		iproto = proto;
-		ikind = IString(Rope.of_string s,lazy s)
-	}
+	VString(Rope.of_string s,lazy s)
 
 let encode_rope s =
 	vstring s

--- a/src/macro/eval/evalEncode.ml
+++ b/src/macro/eval/evalEncode.ml
@@ -109,7 +109,7 @@ let encode_instance ?(kind=INormal) path =
 	vinstance (create_instance ~kind path)
 
 let encode_array_instance a =
-	encode_instance ~kind:(IArray a) key_Array
+	VArray a
 
 let encode_array l =
 	encode_array_instance (EvalArray.create (Array.of_list l))

--- a/src/macro/eval/evalExceptions.ml
+++ b/src/macro/eval/evalExceptions.ml
@@ -35,6 +35,7 @@ let s_value_kind = function
 	| VFloat _ -> "VFloat"
 	| VEnumValue _ -> "VEnumValue"
 	| VObject _ -> "VObject"
+	| VString _ -> "VString"
 	| VInstance _ -> "VInstance"
 	| VPrototype _ -> "VPrototype"
 	| VFunction _ -> "VFunction"

--- a/src/macro/eval/evalExceptions.ml
+++ b/src/macro/eval/evalExceptions.ml
@@ -36,6 +36,7 @@ let s_value_kind = function
 	| VEnumValue _ -> "VEnumValue"
 	| VObject _ -> "VObject"
 	| VString _ -> "VString"
+	| VArray _ -> "VArray"
 	| VInstance _ -> "VInstance"
 	| VPrototype _ -> "VPrototype"
 	| VFunction _ -> "VFunction"

--- a/src/macro/eval/evalField.ml
+++ b/src/macro/eval/evalField.ml
@@ -49,7 +49,7 @@ let field_raise v f =
 	| VObject o -> object_field_raise o f
 	| VInstance {ikind = IBytes s} when f = key_length -> vint (Bytes.length s)
 	| VPrototype proto -> proto_field_raise proto f
-	| VInstance {ikind = IArray va} ->
+	| VArray va ->
 		if f = key_length then vint (va.alength)
 		else proto_field_direct (get_instance_prototype_raise (get_ctx()) key_Array) f
 	| VString (_,s) ->

--- a/src/macro/eval/evalField.ml
+++ b/src/macro/eval/evalField.ml
@@ -52,6 +52,9 @@ let field_raise v f =
 	| VInstance {ikind = IArray va} ->
 		if f = key_length then vint (va.alength)
 		else proto_field_direct (get_instance_prototype_raise (get_ctx()) key_Array) f
+	| VString (_,s) ->
+		if f = key_length then vint (String.length (Lazy.force s))
+		else proto_field_direct (get_ctx()).string_prototype f
 	| VInstance vi -> (try instance_field vi f with Not_found -> proto_field_raise vi.iproto f)
 	| _ -> raise Not_found
 

--- a/src/macro/eval/evalMain.ml
+++ b/src/macro/eval/evalMain.ml
@@ -208,7 +208,7 @@ let rec value_to_expr v p =
 	| VInt32 i -> (EConst (Int (Int32.to_string i)),p)
 	| VFloat f -> haxe_float f p
 	| VString(r,s) -> (EConst (String (Lazy.force s)),p)
-	| VInstance {ikind = IArray va} -> (EArrayDecl (List.map (fun v -> value_to_expr v p) (EvalArray.to_list va)),p)
+	| VArray va -> (EArrayDecl (List.map (fun v -> value_to_expr v p) (EvalArray.to_list va)),p)
 	| VObject o -> (EObjectDecl (List.map (fun (k,v) -> ((rev_hash_s k,p),(value_to_expr v p))) (object_fields o)),p)
 	| VEnumValue e ->
 		let epath =

--- a/src/macro/eval/evalMain.ml
+++ b/src/macro/eval/evalMain.ml
@@ -207,7 +207,7 @@ let rec value_to_expr v p =
 	| VFalse -> (EConst (Ident "false"),p)
 	| VInt32 i -> (EConst (Int (Int32.to_string i)),p)
 	| VFloat f -> haxe_float f p
-	| VInstance {ikind = IString(r,s)} -> (EConst (String (Lazy.force s)),p)
+	| VString(r,s) -> (EConst (String (Lazy.force s)),p)
 	| VInstance {ikind = IArray va} -> (EArrayDecl (List.map (fun v -> value_to_expr v p) (EvalArray.to_list va)),p)
 	| VObject o -> (EObjectDecl (List.map (fun (k,v) -> ((rev_hash_s k,p),(value_to_expr v p))) (object_fields o)),p)
 	| VEnumValue e ->

--- a/src/macro/eval/evalMisc.ml
+++ b/src/macro/eval/evalMisc.ml
@@ -79,7 +79,7 @@ let rec compare a b =
 	| VTrue,VTrue | VFalse,VFalse -> CEq
 	| VFalse,VTrue -> CInf
 	| VTrue,VFalse -> CSup
-	| VInstance {ikind = IString(_,s1)},VInstance {ikind = IString(_,s2)} ->
+	| VString(_,s1),VString(_,s2) ->
 		let r = String.compare (Lazy.force s1) (Lazy.force s2) in
 		if r = 0 then CEq else if r < 0 then CInf else CSup
 	| VFunction(a,_), VFunction(b,_) -> if a == b then CEq else CUndef
@@ -105,9 +105,8 @@ let rec equals a b = match a,b with
 	| VFloat a,VInt32 b -> a = (Int32.to_float b)
 	| VInt32 a,VFloat b -> (Int32.to_float a) = b
 	| VTrue,VTrue | VFalse,VFalse -> true
-	| VInstance {ikind = IString(r1,s1)},VInstance {ikind = IString(r2,s2)} -> r1 == r2 || Lazy.force s1 = Lazy.force s2
+	| VString(r1,s1),VString(r2,s2) -> r1 == r2 || Lazy.force s1 = Lazy.force s2
 	| VFunction(a,_),VFunction(b,_) -> a == b
-	| VInstance {ikind = IArray a},VInstance {ikind = IArray b} -> a == b
 	| VObject a,VObject b -> a == b
 	| VInstance a,VInstance b -> a == b
 	| VPrototype a,VPrototype b -> a == b
@@ -135,7 +134,7 @@ and equals_structurally a b =
 	| VFloat a,VInt32 b -> a = (Int32.to_float b)
 	| VInt32 a,VFloat b -> (Int32.to_float a) = b
 	| VTrue,VTrue | VFalse,VFalse -> true
-	| VInstance {ikind = IString(_,s1)},VInstance {ikind = IString(_,s2)} -> Lazy.force s1 = Lazy.force s2
+	| VString(_,s1),VString(_,s2) -> Lazy.force s1 = Lazy.force s2
 	| VFunction(a,_),VFunction(b,_) -> a == b
 	| VInstance {ikind = IArray a},VInstance {ikind = IArray b} -> a == b || arrays_equal a.avalues b.avalues
 	| VObject a,VObject b -> a == b || arrays_equal a.ofields b.ofields && IntMap.equal equals_structurally a.oextra b.oextra
@@ -153,6 +152,7 @@ let is v path =
 	| VPrototype {pkind = PClass _} -> path = key_Class
 	| VPrototype {pkind = PEnum _} -> path = key_Enum
 	| VEnumValue ve -> path = key_EnumValue || path = ve.epath
+	| VString _ -> path = key_String
 	| VInstance vi ->
 		let has_interface path' =
 			try begin match (get_static_prototype_raise (get_ctx()) path').pkind with

--- a/src/macro/eval/evalPrinting.ml
+++ b/src/macro/eval/evalPrinting.ml
@@ -102,7 +102,7 @@ and s_value depth v =
 		concat2 rfun (Rope.of_string (s))
 	| VFieldClosure _ -> rclosure
 	| VEnumValue ve -> s_enum_value depth ve
-	| VInstance {ikind = IString(s,_)} -> s
+	| VString(s,_) -> s
 	| VInstance {ikind = IArray va} -> s_array (depth + 1) va
 	| VInstance {ikind=IDate d} -> s_date d
 	| VInstance {ikind=IPos p} -> of_string ("#pos(" ^ Lexer.get_error_pos (Printf.sprintf "%s:%d:") p ^ ")")

--- a/src/macro/eval/evalPrinting.ml
+++ b/src/macro/eval/evalPrinting.ml
@@ -103,7 +103,7 @@ and s_value depth v =
 	| VFieldClosure _ -> rclosure
 	| VEnumValue ve -> s_enum_value depth ve
 	| VString(s,_) -> s
-	| VInstance {ikind = IArray va} -> s_array (depth + 1) va
+	| VArray va -> s_array (depth + 1) va
 	| VInstance {ikind=IDate d} -> s_date d
 	| VInstance {ikind=IPos p} -> of_string ("#pos(" ^ Lexer.get_error_pos (Printf.sprintf "%s:%d:") p ^ ")")
 	| VInstance i -> (try call_to_string () with Not_found -> rev_hash i.iproto.ppath)

--- a/src/macro/eval/evalValue.ml
+++ b/src/macro/eval/evalValue.ml
@@ -63,6 +63,7 @@ type value =
 	| VEnumValue of venum_value
 	| VObject of vobject
 	| VInstance of vinstance
+	| VString of vstring
 	| VPrototype of vprototype
 	| VFunction of vfunc * bool
 	| VFieldClosure of value * vfunc
@@ -109,7 +110,6 @@ and vprototype = {
 
 and vinstance_kind =
 	| IArray of varray
-	| IString of vstring
 	| IBytes of bytes
 	| IRegex of vregex
 	| IDate of float

--- a/src/macro/eval/evalValue.ml
+++ b/src/macro/eval/evalValue.ml
@@ -64,6 +64,7 @@ type value =
 	| VObject of vobject
 	| VInstance of vinstance
 	| VString of vstring
+	| VArray of varray
 	| VPrototype of vprototype
 	| VFunction of vfunc * bool
 	| VFieldClosure of value * vfunc
@@ -109,7 +110,6 @@ and vprototype = {
 }
 
 and vinstance_kind =
-	| IArray of varray
 	| IBytes of bytes
 	| IRegex of vregex
 	| IDate of float


### PR DESCRIPTION
This brings back top-level values for Array and String instances. I went back and forth with this during early development and for a while didn't think this was worth it. However, looking at it again, it does simplify some things and some benchmarks show a small difference.

VString is mostly useful because we no longer need a special case for equality checks on instances. String is the only class type that does not follow physical equality rules for `==`, so it makes sense to have it as a separate value.

I didn't think VArray would make much of a difference, but the haxe-checkstyle tests went from 6s to 5.5s with this change, which at this point is significant. They must be using a lot of arrays...