### PR TITLE
[python] don't inline StringImpl#lastIndexOf/#indexOf

### DIFF
--- a/std/python/internal/StringImpl.hx
+++ b/std/python/internal/StringImpl.hx
@@ -44,7 +44,7 @@ class StringImpl {
 	}
 
 	@:ifFeature("dynamic_read.lastIndexOf", "anon_optional_read.lastIndexOf", "python.internal.StringImpl.lastIndexOf")
-	public static inline function lastIndexOf(s:String, str:String, ?startIndex:Int):Int {
+	public static function lastIndexOf(s:String, str:String, ?startIndex:Int):Int {
 		if (str == "") {
 			var i = startIndex == null ? s.length : startIndex;
 			return UBuiltins.max(0, UBuiltins.min(i,  s.length));
@@ -73,7 +73,7 @@ class StringImpl {
 		return Syntax.callField(s, "lower");
 	}
 	@:ifFeature("dynamic_read.indexOf", "anon_optional_read.indexOf", "python.internal.StringImpl.indexOf")
-	public static inline function indexOf (s:String, str:String, ?startIndex:Int) {
+	public static function indexOf (s:String, str:String, ?startIndex:Int) {
 		if (str == "") {
 			var i = startIndex == null ? 0 : startIndex;
 			return UBuiltins.max(0, UBuiltins.min(i,  s.length));


### PR DESCRIPTION
Because their method body is quite big.